### PR TITLE
Format interfaces nicely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- These interfaces are formatted nicer in logs.
+    - [`encoding.TextMarshaler`](https://golang.org/pkg/encoding/#TextMarshaler)
+    - [`json.Marshaler`](https://golang.org/pkg/encoding/json/#Marshaler)
+    - [`error`](https://golang.org/pkg/builtin/#error)
 
 ## [1.1.1] - 2016-08-24
 ### Added

--- a/logfmt.go
+++ b/logfmt.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"encoding"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -183,6 +184,27 @@ func appendLogfmt(buf []byte, v interface{}) ([]byte, error) {
 			return nil, ErrTooLarge
 		}
 		return strconv.AppendQuote(buf, t), nil
+	case encoding.TextMarshaler:
+		// TextMarshaler encodes into UTF-8 string.
+		s, err := t.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+		if cap(buf) < (len(s)*2 + 2) {
+			return nil, ErrTooLarge
+		}
+		return strconv.AppendQuote(buf, string(s)), nil
+	case error:
+		s := t.Error()
+		if !utf8.ValidString(s) {
+			// the next line replaces invalid characters.
+			s = string([]rune(s))
+		}
+		// escaped length = 2*len(s) + 2 double quotes
+		if cap(buf) < (len(s)*2 + 2) {
+			return nil, ErrTooLarge
+		}
+		return strconv.AppendQuote(buf, s), nil
 	}
 
 	value := reflect.ValueOf(v)


### PR DESCRIPTION
This PR improves formatters for these interfaces:
- [`encoding.TextMarshaler`](https://golang.org/pkg/encoding/#TextMarshaler)
  
  This interface explicitly declares that the object can be marshaled into UTF-8 string.
- [`json.Marshaler`](https://golang.org/pkg/encoding/json/#Marshaler)
  
  This interface produces JSON.  `JSONFormat` should use it.
- `error`
  
  `Error` should be used instead of `fmt.Sprintf("%#v")`.
