### PR TITLE
Handle errors in Logger.WriteThrough

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -334,7 +334,15 @@ func (l *Logger) Debug(msg string, fields map[string]interface{}) error {
 // WriteThrough writes data through to the underlying writer.
 func (l *Logger) WriteThrough(data []byte) error {
 	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	_, err := l.output.Write(data)
-	l.mu.Unlock()
-	return err
+	if err == nil {
+		return nil
+	}
+	err = l.handleError(err)
+	if err == nil {
+		return nil
+	}
+	return errors.Wrap(err, "Logger.WriteThrough")
 }

--- a/testcmd/main.go
+++ b/testcmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -15,7 +16,15 @@ var (
 	flgIgnoreSigPipe     = flag.Bool("i", false, "ignore SIGPIPE")
 	flgClearErrorHandler = flag.Bool("c", false, "clear error handler")
 	flgStdout            = flag.Bool("s", false, "output to stdout")
+	flgWriteThrough      = flag.Bool("w", false, "use WriteThrough")
 )
+
+func printError(e error) {
+	if e == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "error: %T %#v\n", e, e)
+}
 
 func main() {
 	flag.Parse()
@@ -45,7 +54,11 @@ func main() {
 	}
 
 	for {
-		logger.Error("foo", nil)
+		if *flgWriteThrough {
+			printError(logger.WriteThrough([]byte("foo\n")))
+		} else {
+			printError(logger.Error("foo", nil))
+		}
 		time.Sleep(time.Second)
 	}
 }


### PR DESCRIPTION
This PR fixes #13.

In addition, a possible race condition in Logger.Log is fixed and refactored.

Test results just like #12:

```
$ ./testcmd -w
$ echo $?
5

$ ./testcmd -w -s | true
$ echo $PIPESTATUS
141

$ ./testcmd -w -s -i | true
$ echo $PIPESTATUS
5

$ ./testcmd -w -c | true
error: *errors.withStack Logger.WriteThrough: write |1: broken pipe
error: *errors.withStack Logger.WriteThrough: write |1: broken pipe
error: *errors.withStack Logger.WriteThrough: write |1: broken pipe
^C
```