### PR TITLE
`logWriter` should buffers unwritten bytes

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -235,7 +235,7 @@ func (w *logWriter) Write(p []byte) (int, error) {
 	if cap(w.buf) < remain {
 		return n, errors.New("too long")
 	}
-	w.buf = append(w.buf, tbuf[n:]...)
+	w.buf = append(w.buf, tbuf[written:]...)
 	return len(p), nil
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -104,11 +104,11 @@ func TestLogger(t *testing.T) {
 type testFormat struct {
 }
 
-func (f *testFormat) String() string {
+func (f testFormat) String() string {
 	return "test"
 }
 
-func (f *testFormat) Format(buf []byte, l *Logger, t time.Time, severity int, msg string, fields map[string]interface{}) ([]byte, error) {
+func (f testFormat) Format(buf []byte, l *Logger, t time.Time, severity int, msg string, fields map[string]interface{}) ([]byte, error) {
 	return []byte(msg), nil
 }
 
@@ -116,7 +116,7 @@ func TestWriter(t *testing.T) {
 	l := NewLogger()
 	output := new(bytes.Buffer)
 	l.SetOutput(output)
-	l.SetFormatter(&testFormat{})
+	l.SetFormatter(testFormat{})
 	w := l.Writer(LvCritical)
 
 	cases := []struct {

--- a/logger_test.go
+++ b/logger_test.go
@@ -134,7 +134,7 @@ func TestWriter(t *testing.T) {
 		}
 		actual := output.Bytes()
 		if bytes.Compare(actual, tc.Expected) != 0 {
-			t.Errorf("actual: %s, expected: %s\n", string(actual), string(tc.Expected))
+			t.Errorf("actual: %s, expected: %s", string(actual), string(tc.Expected))
 		}
 		output.Reset()
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -133,7 +133,7 @@ func TestWriter(t *testing.T) {
 			t.Fatal(err)
 		}
 		actual := output.Bytes()
-		if bytes.Compare(actual, tc.Expected) != 0 {
+		if !bytes.Equal(actual, tc.Expected) {
 			t.Errorf("actual: %s, expected: %s", string(actual), string(tc.Expected))
 		}
 		output.Reset()


### PR DESCRIPTION
- fix a bug in `logWriter.Write`
- add test for `Logger.Writer`