### PR TITLE
use strings.ToValidUTF8 to validate string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/cybozu-go/log
 
+go 1.13
+
 require github.com/pkg/errors v0.8.0

--- a/json.go
+++ b/json.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -190,7 +191,7 @@ func appendJSON(buf []byte, v interface{}) ([]byte, error) {
 	case string:
 		if !utf8.ValidString(t) {
 			// the next line replaces invalid characters.
-			t = string([]rune(t))
+			t = strings.ToValidUTF8(t, string(utf8.RuneError))
 		}
 		// escaped length = 2*len(t) + 2 double quotes
 		if cap(buf) < (len(t)*2 + 2) {
@@ -226,7 +227,7 @@ func appendJSON(buf []byte, v interface{}) ([]byte, error) {
 		s := t.Error()
 		if !utf8.ValidString(s) {
 			// the next line replaces invalid characters.
-			s = string([]rune(s))
+			s = strings.ToValidUTF8(s, string(utf8.RuneError))
 		}
 		// escaped length = 2*len(s) + 2 double quotes
 		if cap(buf) < (len(s)*2 + 2) {

--- a/logfmt.go
+++ b/logfmt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -186,7 +187,7 @@ func appendLogfmt(buf []byte, v interface{}) ([]byte, error) {
 	case string:
 		if !utf8.ValidString(t) {
 			// the next line replaces invalid characters.
-			t = string([]rune(t))
+			t = strings.ToValidUTF8(t, string(utf8.RuneError))
 		}
 		// escaped length = 2*len(t) + 2 double quotes
 		if cap(buf) < (len(t)*2 + 2) {
@@ -207,7 +208,7 @@ func appendLogfmt(buf []byte, v interface{}) ([]byte, error) {
 		s := t.Error()
 		if !utf8.ValidString(s) {
 			// the next line replaces invalid characters.
-			s = string([]rune(s))
+			s = strings.ToValidUTF8(s, string(utf8.RuneError))
 		}
 		// escaped length = 2*len(s) + 2 double quotes
 		if cap(buf) < (len(s)*2 + 2) {

--- a/plain.go
+++ b/plain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -188,7 +189,7 @@ func appendPlain(buf []byte, v interface{}) ([]byte, error) {
 	case string:
 		if !utf8.ValidString(t) {
 			// the next line replaces invalid characters.
-			t = string([]rune(t))
+			t = strings.ToValidUTF8(t, " ")
 		}
 		// escaped length = 2*len(t) + 2 double quotes
 		if cap(buf) < (len(t)*2 + 2) {
@@ -209,7 +210,7 @@ func appendPlain(buf []byte, v interface{}) ([]byte, error) {
 		s := t.Error()
 		if !utf8.ValidString(s) {
 			// the next line replaces invalid characters.
-			s = string([]rune(s))
+			s = strings.ToValidUTF8(s, " ")
 		}
 		// escaped length = 2*len(s) + 2 double quotes
 		if cap(buf) < (len(s)*2 + 2) {

--- a/plain.go
+++ b/plain.go
@@ -189,7 +189,7 @@ func appendPlain(buf []byte, v interface{}) ([]byte, error) {
 	case string:
 		if !utf8.ValidString(t) {
 			// the next line replaces invalid characters.
-			t = strings.ToValidUTF8(t, " ")
+			t = strings.ToValidUTF8(t, string(utf8.RuneError))
 		}
 		// escaped length = 2*len(t) + 2 double quotes
 		if cap(buf) < (len(t)*2 + 2) {
@@ -210,7 +210,7 @@ func appendPlain(buf []byte, v interface{}) ([]byte, error) {
 		s := t.Error()
 		if !utf8.ValidString(s) {
 			// the next line replaces invalid characters.
-			s = strings.ToValidUTF8(s, " ")
+			s = strings.ToValidUTF8(s, string(utf8.RuneError))
 		}
 		// escaped length = 2*len(s) + 2 double quotes
 		if cap(buf) < (len(s)*2 + 2) {

--- a/plain_test.go
+++ b/plain_test.go
@@ -2,8 +2,10 @@ package log
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 func TestAppendPlain(t *testing.T) {
@@ -52,6 +54,38 @@ func TestAppendPlain(t *testing.T) {
 			t.Error(`!bytes.Contain(b, "-1")`)
 		}
 	}
+
+	invalidUtf8 := "hello" + string([]byte{0x80})
+	b, err = appendPlain(buf, invalidUtf8)
+	if err != nil {
+		t.Error(err)
+	} else {
+		if !utf8.ValidString(string(b)) {
+			t.Error(`!utf8.ValidString(b)`)
+		}
+		if bytes.Contains(b, []byte("x80")) {
+			t.Error(`bytes.Contains(b, "x80")`)
+		}
+		if !bytes.Contains(b, []byte("hello")) {
+			t.Error(`!bytes.Contains(b, "hello")`)
+		}
+	}
+
+	b, err = appendPlain(buf, fmt.Errorf(invalidUtf8))
+	if err != nil {
+		t.Error(err)
+	} else {
+		if !utf8.ValidString(string(b)) {
+			t.Error(`!utf8.ValidString(b)`)
+		}
+		if bytes.Contains(b, []byte("x80")) {
+			t.Error(`bytes.Contains(b, "x80")`)
+		}
+		if !bytes.Contains(b, []byte("hello")) {
+			t.Error(`!bytes.Contains(b, "hello")`)
+		}
+	}
+
 }
 
 const (


### PR DESCRIPTION
ref #19 

The patch replaces invalid utf8 string with whitespace.
e.g.
`hello\x80world` -> `hello world`

I just modified only plain*.go.  Could you review it ?
If the review is ok, I will modify json*.go and logfmt*.go.

