### PR TITLE
update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.6.0] - 2020-03-19
+### Changed
+- Validate string with strings.ToValidUTF8 (#26).
+
 ## [1.5.0] - 2018-09-14
 ### Added
 - Opting in to [Go modules](https://github.com/golang/go/wiki/Modules).
@@ -58,7 +62,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [Logger.Writer](https://godoc.org/github.com/cybozu-go/log#Logger.Writer) is rewritten for better performance.
 
-[Unreleased]: https://github.com/cybozu-go/log/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/cybozu-go/log/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/cybozu-go/log/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/cybozu-go/log/compare/v1.4.2...v1.5.0
 [1.4.2]: https://github.com/cybozu-go/log/compare/v1.4.0...v1.4.2
 [1.4.1]: https://github.com/cybozu-go/log/compare/v1.4.0...v1.4.1


### PR DESCRIPTION
v1.6.0 has been released, so I updated CHANGELOG.md.

## differences from previous version.

https://github.com/cybozu-go/log/compare/v1.5.0...v1.6.0

PRs are #20 #21 #22 #23 #24 #26
Almost all fixed/enhanced Circle CI, so I didn't write about them.

