### PR TITLE
Fix JSONFormat to ensure outputting JSON on NaN and Infinities

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -111,6 +112,8 @@ func TestJSONFormat(t *testing.T) {
 
 	b, err = f.Format(buf, l, ts, LvDebug, "fuga fuga", map[string]interface{}{
 		"abc":     []int{1, 2, 3},
+		"float32": []float32{3.14159, float32(math.NaN()), float32(math.Inf(1)), float32(math.Inf(-1))},
+		"float64": []float64{3.14159, math.NaN(), math.Inf(1), math.Inf(-1)},
 		"invalid": "12\xc534",
 		"tm":      testTextMarshal{},
 		"jm":      testJSONMarshal{},
@@ -153,7 +156,25 @@ func TestJSONFormat(t *testing.T) {
 	} else {
 		if !reflect.DeepEqual(v.([]interface{}), []interface{}{1.0, 2.0, 3.0}) {
 			t.Error(`!reflect.DeepEqual(v.([]interface{}), []interface{}{1, 2, 3})`)
-			t.Logf("%#v", v.([]interface{}))
+			t.Logf("%#v", v)
+		}
+	}
+
+	if v, ok := j["float32"]; !ok {
+		t.Error(`v, ok := j["float32"]; !ok`)
+	} else {
+		if !reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"}) {
+			t.Error(`!reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"})`)
+			t.Logf("%#v", v)
+		}
+	}
+
+	if v, ok := j["float64"]; !ok {
+		t.Error(`v, ok := j["float64"]; !ok`)
+	} else {
+		if !reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"}) {
+			t.Error(`!reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"})`)
+			t.Logf("%#v", v)
 		}
 	}
 

--- a/logfmt_test.go
+++ b/logfmt_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -44,19 +45,44 @@ func TestAppendLogfmt(t *testing.T) {
 		t.Error(string(b) + ` != "\"abc "`)
 	}
 
+	b, _ = appendLogfmt(buf, float32(3.14159))
+	if string(b) != "3.14159" {
+		t.Error(string(b) + ` != "3.14159"`)
+	}
+
+	b, _ = appendLogfmt(buf, 3.14159)
+	if string(b) != "3.14159" {
+		t.Error(string(b) + ` != "3.14159"`)
+	}
+
+	b, _ = appendLogfmt(buf, math.NaN())
+	if string(b) != "NaN" {
+		t.Error(string(b) + ` != "NaN"`)
+	}
+
+	b, _ = appendLogfmt(buf, math.Inf(1))
+	if string(b) != "+Inf" {
+		t.Error(string(b) + ` != "+Inf"`)
+	}
+
+	b, _ = appendLogfmt(buf, math.Inf(-1))
+	if string(b) != "-Inf" {
+		t.Error(string(b) + ` != "-Inf"`)
+	}
+
 	b, _ = appendLogfmt(buf, []int{-100, 100, 20000})
-	if string(b) != `[-100 100 20000]` {
-		t.Error("failed to format int list")
+	if string(b) != "[-100 100 20000]" {
+		t.Error(string(b) + ` != "[-100 100 20000]"`)
 	}
 
 	b, _ = appendLogfmt(buf, []int64{-100, 100, 20000})
-	if string(b) != `[-100 100 20000]` {
-		t.Error("failed to format int64 list")
+	if string(b) != "[-100 100 20000]" {
+		t.Error(string(b) + ` != "[-100 100 20000]"`)
 	}
 
 	b, _ = appendLogfmt(buf, []string{"abc", "def"})
 	if string(b) != `["abc" "def"]` {
-		t.Error("failed to format string list")
+		t.Error(string(b) + ` != ["abc" "def"]`)
 	}
 
 	b, _ = appendLogfmt(buf, map[string]interface{}{

--- a/logfmt_test.go
+++ b/logfmt_test.go
@@ -17,56 +17,49 @@ const (
 func TestAppendLogfmt(t *testing.T) {
 	t.Parallel()
 
-	b := make([]byte, 0, 4096)
-	b, _ = appendLogfmt(b, nil)
+	buf := make([]byte, 0, 4096)
+
+	b, _ := appendLogfmt(buf, nil)
 	if string(b) != "null" {
 		t.Error(string(b) + " != null")
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, 100)
+	b, _ = appendLogfmt(buf, 100)
 	if string(b) != "100" {
 		t.Error(string(b) + " != 100")
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, false)
+	b, _ = appendLogfmt(buf, false)
 	if string(b) != "false" {
 		t.Error(string(b) + " != false")
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, true)
+	b, _ = appendLogfmt(buf, true)
 	if string(b) != "true" {
 		t.Error(string(b) + " != true")
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, `"abc `)
+	b, _ = appendLogfmt(buf, `"abc `)
 	if string(b) != `"\"abc "` {
 		t.Error(string(b) + ` != "\"abc "`)
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, []int{-100, 100, 20000})
+	b, _ = appendLogfmt(buf, []int{-100, 100, 20000})
 	if string(b) != `[-100 100 20000]` {
 		t.Error("failed to format int list")
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, []int64{-100, 100, 20000})
+	b, _ = appendLogfmt(buf, []int64{-100, 100, 20000})
 	if string(b) != `[-100 100 20000]` {
 		t.Error("failed to format int64 list")
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, []string{"abc", "def"})
+	b, _ = appendLogfmt(buf, []string{"abc", "def"})
 	if string(b) != `["abc" "def"]` {
 		t.Error("failed to format string list")
 	}
 
-	b = b[:0]
-	b, _ = appendLogfmt(b, map[string]interface{}{
+	b, _ = appendLogfmt(buf, map[string]interface{}{
 		"abc":     123,
 		"def ghi": nil,
 	})
@@ -76,8 +69,7 @@ func TestAppendLogfmt(t *testing.T) {
 	}
 
 	invalidUtf8 := "hello" + string([]byte{0x80})
-	b = b[:0]
-	b, err := appendLogfmt(b, invalidUtf8)
+	b, err := appendLogfmt(buf, invalidUtf8)
 	if err != nil {
 		t.Error(err)
 	} else {
@@ -92,8 +84,7 @@ func TestAppendLogfmt(t *testing.T) {
 		}
 	}
 
-	b = b[:0]
-	b, err = appendLogfmt(b, fmt.Errorf(invalidUtf8))
+	b, err = appendLogfmt(buf, fmt.Errorf(invalidUtf8))
 	if err != nil {
 		t.Error(err)
 	} else {

--- a/plain_test.go
+++ b/plain_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -15,17 +16,52 @@ func TestAppendPlain(t *testing.T) {
 
 	b, _ := appendPlain(buf, nil)
 	if string(b) != "null" {
-		t.Error(`string(b) != "null"`)
+		t.Error(string(b) + ` != "null"`)
+	}
+
+	b, _ = appendLogfmt(buf, 100)
+	if string(b) != "100" {
+		t.Error(string(b) + " != 100")
+	}
+
+	b, _ = appendPlain(buf, false)
+	if string(b) != "false" {
+		t.Error(string(b) + ` != "false"`)
 	}
 
 	b, _ = appendPlain(buf, true)
 	if string(b) != "true" {
-		t.Error(`string(b) != "true"`)
+		t.Error(string(b) + ` != "true"`)
 	}
 
 	b, _ = appendPlain(buf, int16(-12345))
 	if string(b) != "-12345" {
-		t.Error(`string(b) != "-12345"`)
+		t.Error(string(b) + ` != "-12345"`)
+	}
+
+	b, _ = appendPlain(buf, float32(3.14159))
+	if string(b) != "3.14159" {
+		t.Error(string(b) + ` != "3.14159"`)
+	}
+
+	b, _ = appendPlain(buf, 3.14159)
+	if string(b) != "3.14159" {
+		t.Error(string(b) + ` != "3.14159"`)
+	}
+
+	b, _ = appendPlain(buf, math.NaN())
+	if string(b) != "NaN" {
+		t.Error(string(b) + ` != "NaN"`)
+	}
+
+	b, _ = appendPlain(buf, math.Inf(1))
+	if string(b) != "+Inf" {
+		t.Error(string(b) + ` != "+Inf"`)
+	}
+
+	b, _ = appendPlain(buf, math.Inf(-1))
+	if string(b) != "-Inf" {
+		t.Error(string(b) + ` != "-Inf"`)
 	}
 
 	b, err := appendPlain(buf, []string{"abc", "def"})


### PR DESCRIPTION
Currently ([v1.6.1](https://github.com/cybozu-go/log/releases/tag/v1.6.1)) `JSONFormat` emits non-JSON on NaN and Infinities.
This PR fixes `JSONFormat` to ensure the output to be JSON on NaN and Infinities.
Also added tests for `Logfmt` and `PlainFormat` to cover these values (behavior not changed).

### Sample code
```go
package main

import (
	"encoding/json"
	"fmt"
	"math"
	"os"
	"time"

	"github.com/cybozu-go/log"
)

func main() {
	var err error
	l := log.NewLogger()
	f := log.JSONFormat{Utsname: "test"}
	t := time.Now()

	buf := make([]byte, 0, 256)
	buf, err = f.Format(buf, l, t, log.LvDebug, "test", map[string]interface{}{
		"x": math.NaN(),
		"y": math.Inf(1),
		"z": math.Inf(-1),
	})
	if err != nil {
		fmt.Fprintf(os.Stderr, "%s\n", err)
		os.Exit(1)
	}
	fmt.Printf("%s\n", buf)

	var data interface{}
	err = json.Unmarshal(buf, &data)
	if err != nil {
		fmt.Fprintf(os.Stderr, "%s\n", err)
		os.Exit(1)
	}
	fmt.Printf("%v\n", data)
}
```

### Result
```
{"topic":"main","logged_at":"2022-03-14T01:37:50.253201Z","severity":"debug","utsname":"test","message":"test","x":NaN,"y":+Inf,"z":-Inf}

invalid character 'N' looking for beginning of value
exit status 1
```

### Expected behavior
I expect this logger either to emit valid JSON or to return error.
Considering the expectation against loggers, I think it is better to emit JSON to allow restoration of the original data.

- Return an error just like `encoding/json`: Losing log data on invalid data is unacceptable as a logger.
- Output `"NaN"`, `"+Inf"`, `"-Inf"` like [`zap`](https://github.com/uber-go/zap): Allows restoration of the original data, except for the confusion against string values.
  - This PR implements this behavior.
- Output `null`, `1.7976931348623157e+308`, `-1.7976931348623157e+308` like [`jq`](https://stedolan.github.io/jq/manual/): Familiar behavior of jq user, and keeps the number type, but cannot distinguish `null` and `NaN` and this is confusing.
