### PR TITLE
Rewrite logger tests into got/want style to omit expectation duplicates

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -57,48 +57,48 @@ func TestJSONFormat(t *testing.T) {
 	if v, ok := j[FnTopic]; !ok {
 		t.Error(`v, ok := j[FnTopic]; !ok`)
 	} else {
-		if v.(string) != "topic1" {
-			t.Error(`v.(string) != "topic1"`)
+		if got, want := v.(string), "topic1"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j[FnLoggedAt]; !ok {
 		t.Error(`v, ok := j[FnLoggedAt]; !ok`)
 	} else {
-		if v.(string) != "2001-12-03T13:45:01.123456Z" {
-			t.Error(`v.(string) != "2001-12-03T13:45:01.123456Z"`)
+		if got, want := v.(string), "2001-12-03T13:45:01.123456Z"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j[FnUtsname]; !ok {
 		t.Error(`v, ok := j[FnUtsname]; !ok`)
 	} else {
-		if v.(string) != "localhost" {
-			t.Error(`v.(string) != "localhost"`)
+		if got, want := v.(string), "localhost"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j[FnSeverity]; !ok {
 		t.Error(`v, ok := j[FnSeverity]; !ok`)
 	} else {
-		if v.(string) != "critical" {
-			t.Error(`v.(string) != "critical"`)
+		if got, want := v.(string), "critical"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j[FnMessage]; !ok {
 		t.Error(`v, ok := j[FnMessage]; !ok`)
 	} else {
-		if v.(string) != "hoge" {
-			t.Error(`v.(string) != "hoge"`)
+		if got, want := v.(string), "hoge"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j["abc"]; !ok {
 		t.Error(`v, ok := j["abc"]; !ok`)
 	} else {
-		if int(v.(float64)) != 123 {
-			t.Error(`int(v.(float64)) != 123`)
+		if got, want := int(v.(float64)), 123; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
@@ -138,43 +138,40 @@ func TestJSONFormat(t *testing.T) {
 	if v, ok := j[FnSeverity]; !ok {
 		t.Error(`v, ok := j[FnSeverity]; !ok`)
 	} else {
-		if v.(string) != "debug" {
-			t.Error(`v.(string) != "debug"`)
+		if got, want := v.(string), "debug"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j[FnMessage]; !ok {
 		t.Error(`v, ok := j[FnMessage]; !ok`)
 	} else {
-		if v.(string) != "fuga fuga" {
-			t.Error(`v.(string) != "fuga fuga"`)
+		if got, want := v.(string), "fuga fuga"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j["abc"]; !ok {
 		t.Error(`v, ok := j["abc"]; !ok`)
 	} else {
-		if !reflect.DeepEqual(v.([]interface{}), []interface{}{1.0, 2.0, 3.0}) {
-			t.Error(`!reflect.DeepEqual(v.([]interface{}), []interface{}{1, 2, 3})`)
-			t.Logf("%#v", v)
+		if got, want := v.([]interface{}), []interface{}{1.0, 2.0, 3.0}; !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
 		}
 	}
 
 	if v, ok := j["float32"]; !ok {
 		t.Error(`v, ok := j["float32"]; !ok`)
 	} else {
-		if !reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"}) {
-			t.Error(`!reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"})`)
-			t.Logf("%#v", v)
+		if got, want := v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
 		}
 	}
 
 	if v, ok := j["float64"]; !ok {
 		t.Error(`v, ok := j["float64"]; !ok`)
 	} else {
-		if !reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"}) {
-			t.Error(`!reflect.DeepEqual(v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"})`)
-			t.Logf("%#v", v)
+		if got, want := v.([]interface{}), []interface{}{3.14159, "NaN", "+Inf", "-Inf"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
 		}
 	}
 
@@ -189,32 +186,32 @@ func TestJSONFormat(t *testing.T) {
 	if v, ok := j["invalid"]; !ok {
 		t.Error(`v, ok := j["invalid"]; !ok`)
 	} else {
-		if v.(string) != "12\uFFFD34" {
-			t.Error(`v.(string) != "12\uFFFD34"`)
+		if got, want := v.(string), "12\uFFFD34"; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j["tm"]; !ok {
 		t.Error(`v, ok := j["tm"]; !ok`)
 	} else {
-		if v.(string) != `a", b, c` {
-			t.Error("v.(string) != `a\", b, c`")
+		if got, want := v.(string), `a", b, c`; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j["jm"]; !ok {
 		t.Error(`v, ok := j["jm"]; !ok`)
 	} else {
-		if v.(string) != `a", b, c` {
-			t.Error("v.(string) != `a\", b, c`")
+		if got, want := v.(string), `a", b, c`; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
 	if v, ok := j["err"]; !ok {
 		t.Error(`v, ok := j["err"]; !ok`)
 	} else {
-		if v.(string) != `a", b, c` {
-			t.Error("v.(string) != `a\", b, c`")
+		if got, want := v.(string), `a", b, c`; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }

--- a/logfmt_test.go
+++ b/logfmt_test.go
@@ -21,68 +21,68 @@ func TestAppendLogfmt(t *testing.T) {
 	buf := make([]byte, 0, 4096)
 
 	b, _ := appendLogfmt(buf, nil)
-	if string(b) != "null" {
-		t.Error(string(b) + " != null")
+	if got, want := string(b), "null"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, 100)
-	if string(b) != "100" {
-		t.Error(string(b) + " != 100")
+	if got, want := string(b), "100"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, false)
-	if string(b) != "false" {
-		t.Error(string(b) + " != false")
+	if got, want := string(b), "false"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, true)
-	if string(b) != "true" {
-		t.Error(string(b) + " != true")
+	if got, want := string(b), "true"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, `"abc `)
-	if string(b) != `"\"abc "` {
-		t.Error(string(b) + ` != "\"abc "`)
+	if got, want := string(b), `"\"abc "`; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, float32(3.14159))
-	if string(b) != "3.14159" {
-		t.Error(string(b) + ` != "3.14159"`)
+	if got, want := string(b), "3.14159"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, 3.14159)
-	if string(b) != "3.14159" {
-		t.Error(string(b) + ` != "3.14159"`)
+	if got, want := string(b), "3.14159"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, math.NaN())
-	if string(b) != "NaN" {
-		t.Error(string(b) + ` != "NaN"`)
+	if got, want := string(b), "NaN"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, math.Inf(1))
-	if string(b) != "+Inf" {
-		t.Error(string(b) + ` != "+Inf"`)
+	if got, want := string(b), "+Inf"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, math.Inf(-1))
-	if string(b) != "-Inf" {
-		t.Error(string(b) + ` != "-Inf"`)
+	if got, want := string(b), "-Inf"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, []int{-100, 100, 20000})
-	if string(b) != "[-100 100 20000]" {
-		t.Error(string(b) + ` != "[-100 100 20000]"`)
+	if got, want := string(b), "[-100 100 20000]"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, []int64{-100, 100, 20000})
-	if string(b) != "[-100 100 20000]" {
-		t.Error(string(b) + ` != "[-100 100 20000]"`)
+	if got, want := string(b), "[-100 100 20000]"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, []string{"abc", "def"})
-	if string(b) != `["abc" "def"]` {
-		t.Error(string(b) + ` != ["abc" "def"]`)
+	if got, want := string(b), `["abc" "def"]`; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, map[string]interface{}{
@@ -139,8 +139,8 @@ func TestLogfmt1(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", nil); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testLog1 {
-			t.Error(string(buf) + " != " + testLog1)
+		if got, want := string(buf), testLog1; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
@@ -150,8 +150,8 @@ func TestLogfmt1(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", nil); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testLog1 {
-			t.Error(string(buf) + " != " + testLog1)
+		if got, want := string(buf), testLog1; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }
@@ -170,8 +170,8 @@ func TestLogfmt2(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", nil); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testLog2 {
-			t.Error(string(buf) + " != " + testLog2)
+		if got, want := string(buf), testLog2; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
@@ -182,8 +182,8 @@ func TestLogfmt2(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", fields); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testLog3 {
-			t.Error(string(buf) + " != " + testLog3)
+		if got, want := string(buf), testLog3; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }

--- a/plain_test.go
+++ b/plain_test.go
@@ -15,53 +15,53 @@ func TestAppendPlain(t *testing.T) {
 	buf := make([]byte, 0, 4096)
 
 	b, _ := appendPlain(buf, nil)
-	if string(b) != "null" {
-		t.Error(string(b) + ` != "null"`)
+	if got, want := string(b), "null"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendLogfmt(buf, 100)
-	if string(b) != "100" {
-		t.Error(string(b) + " != 100")
+	if got, want := string(b), "100"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, false)
-	if string(b) != "false" {
-		t.Error(string(b) + ` != "false"`)
+	if got, want := string(b), "false"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, true)
-	if string(b) != "true" {
-		t.Error(string(b) + ` != "true"`)
+	if got, want := string(b), "true"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, int16(-12345))
-	if string(b) != "-12345" {
-		t.Error(string(b) + ` != "-12345"`)
+	if got, want := string(b), "-12345"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, float32(3.14159))
-	if string(b) != "3.14159" {
-		t.Error(string(b) + ` != "3.14159"`)
+	if got, want := string(b), "3.14159"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, 3.14159)
-	if string(b) != "3.14159" {
-		t.Error(string(b) + ` != "3.14159"`)
+	if got, want := string(b), "3.14159"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, math.NaN())
-	if string(b) != "NaN" {
-		t.Error(string(b) + ` != "NaN"`)
+	if got, want := string(b), "NaN"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, math.Inf(1))
-	if string(b) != "+Inf" {
-		t.Error(string(b) + ` != "+Inf"`)
+	if got, want := string(b), "+Inf"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, _ = appendPlain(buf, math.Inf(-1))
-	if string(b) != "-Inf" {
-		t.Error(string(b) + ` != "-Inf"`)
+	if got, want := string(b), "-Inf"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	b, err := appendPlain(buf, []string{"abc", "def"})
@@ -144,8 +144,8 @@ func TestPlainFormat1(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", nil); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testPlainLog1 {
-			t.Error(string(buf) + " != " + testPlainLog1)
+		if got, want := string(buf), testPlainLog1; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }
@@ -164,8 +164,8 @@ func TestPlainFormat2(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", nil); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testPlainLog2 {
-			t.Error(string(buf) + " != " + testPlainLog2)
+		if got, want := string(buf), testPlainLog2; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 
@@ -176,8 +176,8 @@ func TestPlainFormat2(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", fields); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testPlainLog3 {
-			t.Error(string(buf) + " != " + testPlainLog3)
+		if got, want := string(buf), testPlainLog3; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }
@@ -200,8 +200,8 @@ func TestPlainFormat3(t *testing.T) {
 	if buf, err := f.Format(b, l, ts, LvDebug, "test message", fields); err != nil {
 		t.Error(err)
 	} else {
-		if string(buf) != testPlainLog4 {
-			t.Error(string(buf) + " != " + testPlainLog4)
+		if got, want := string(buf), testPlainLog4; got != want {
+			t.Errorf("got %q, want %q", got, want)
 		}
 	}
 }


### PR DESCRIPTION
This PR suggests refactoring of logger tests. The current tests duplicates the expectation values in both if statements and error message. Go source suggests to introduce two variables `got`/`want` to omit the value duplicates. This makes much easier to write tests.

References
- https://github.com/golang/go/wiki/TestComments#got-before-want
- https://github.com/golang/go/wiki/CodeReviewComments#useful-test-failures