### PR TITLE
Improve performance of map iteration using reflect.MapIter

### DIFF
--- a/json.go
+++ b/json.go
@@ -247,14 +247,14 @@ func appendJSON(buf []byte, v interface{}) ([]byte, error) {
 		}
 		buf = append(buf, '{')
 		first := true
-		for _, k := range value.MapKeys() {
+		for iter := value.MapRange(); iter.Next(); {
 			if !first {
 				if cap(buf) < 1 {
 					return nil, ErrTooLarge
 				}
 				buf = append(buf, ',')
 			}
-			buf, err = appendJSON(buf, k.String())
+			buf, err = appendJSON(buf, iter.Key().String())
 			if err != nil {
 				return nil, err
 			}
@@ -262,7 +262,7 @@ func appendJSON(buf []byte, v interface{}) ([]byte, error) {
 				return nil, ErrTooLarge
 			}
 			buf = append(buf, ':')
-			buf, err = appendJSON(buf, value.MapIndex(k).Interface())
+			buf, err = appendJSON(buf, iter.Value().Interface())
 			if err != nil {
 				return nil, err
 			}

--- a/logfmt.go
+++ b/logfmt.go
@@ -228,14 +228,14 @@ func appendLogfmt(buf []byte, v interface{}) ([]byte, error) {
 		}
 		buf = append(buf, '{')
 		first := true
-		for _, k := range value.MapKeys() {
+		for iter := value.MapRange(); iter.Next(); {
 			if !first {
 				if cap(buf) < 1 {
 					return nil, ErrTooLarge
 				}
 				buf = append(buf, ' ')
 			}
-			key := k.String()
+			key := iter.Key().String()
 			if regexpValidKey.MatchString(key) {
 				if cap(buf) < len(key) {
 					return nil, ErrTooLarge
@@ -251,7 +251,7 @@ func appendLogfmt(buf []byte, v interface{}) ([]byte, error) {
 				return nil, ErrTooLarge
 			}
 			buf = append(buf, '=')
-			buf, err = appendLogfmt(buf, value.MapIndex(k).Interface())
+			buf, err = appendLogfmt(buf, iter.Value().Interface())
 			if err != nil {
 				return nil, ErrTooLarge
 			}


### PR DESCRIPTION
This PR improves performance of iterating maps, using [reflect.MapIter](https://pkg.go.dev/reflect#MapIter) introduced in Go 1.12.
```
name       old time/op    new time/op    delta
Plain-12     2.21µs ± 2%    2.20µs ± 1%    ~     (p=0.548 n=5+5)
Logfmt-12    1.62µs ± 3%    1.60µs ± 0%  -1.16%  (p=0.016 n=5+4)
JSON-12      1.66µs ± 4%    1.60µs ± 1%  -3.68%  (p=0.008 n=5+5)
```