### PR TITLE
Use buffered channel for signal.Notify

### DIFF
--- a/testcmd/main.go
+++ b/testcmd/main.go
@@ -29,7 +29,7 @@ func printError(e error) {
 func main() {
 	flag.Parse()
 	if *flgIgnoreSigPipe {
-		ch := make(chan os.Signal)
+		ch := make(chan os.Signal, 1)
 		signal.Notify(ch, syscall.SIGPIPE)
 	}
 


### PR DESCRIPTION
The channel for `signal.Notify` must not block; [use buffered channel as documented](https://pkg.go.dev/os/signal#Notify). Found by `go vet ./...`.
```sh
 $ go vet ./...
# github.com/cybozu-go/log/testcmd
testcmd/main.go:33:3: misuse of unbuffered os.Signal channel as argument to signal.Notify
```
If this is intentional, we should add comment.