### PR TITLE
Remove "Requirements" section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ Features
 
     Only for non-Windows systems.
 
-Requirements
-------------
-
-Go 1.13 or greater is required.
-
 Usage
 -----
 


### PR DESCRIPTION
This commit removes the "Requirements" section from README because
we cannot maintain it precisely.
We simply test the code with the latest Go.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>