### PR TITLE
Fix check of buffer capacity

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"math"
 	"reflect"
 	"testing"
@@ -222,5 +223,13 @@ func TestJSONFormat(t *testing.T) {
 		if got, want := v.(string), `a", b, c`; got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}
+	}
+
+	long_input := make([]byte, 4096)
+	_, err = f.Format(buf, l, ts, LvCritical, "baz", map[string]interface{}{
+		"key": long_input,
+	})
+	if !errors.Is(err, ErrTooLarge) {
+		t.Errorf("got: %#v, want: %#v", err, ErrTooLarge)
 	}
 }

--- a/logfmt_test.go
+++ b/logfmt_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"testing"
@@ -123,6 +124,14 @@ func TestAppendLogfmt(t *testing.T) {
 		if !bytes.Contains(b, []byte("hello")) {
 			t.Error(`!bytes.Contains(b, "hello")`)
 		}
+	}
+
+	input := "\x00\x00\x00\x00"
+	expected := `"\x00\x00\x00\x00"`
+	buf = make([]byte, 1, len(expected))
+	_, err = appendLogfmt(buf, input)
+	if !errors.Is(err, ErrTooLarge) {
+		t.Errorf("got: %#v, want: %#v", err, ErrTooLarge)
 	}
 }
 

--- a/plain_test.go
+++ b/plain_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math"
 	"testing"
@@ -19,7 +20,7 @@ func TestAppendPlain(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 
-	b, _ = appendLogfmt(buf, 100)
+	b, _ = appendPlain(buf, 100)
 	if got, want := string(b), "100"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -122,6 +123,13 @@ func TestAppendPlain(t *testing.T) {
 		}
 	}
 
+	input := "\x00\x00\x00\x00"
+	expected := `"\x00\x00\x00\x00"`
+	buf = make([]byte, 1, len(expected))
+	_, err = appendPlain(buf, input)
+	if !errors.Is(err, ErrTooLarge) {
+		t.Errorf("got: %#v, want: %#v", err, ErrTooLarge)
+	}
 }
 
 const (


### PR DESCRIPTION
This commit fixes the confirmation of the buffer capacity.
* Use `cap(buf)-len(buf)` instead of `cap(buf)` to calculate
    the remaining capacity of the buffer
* Fix the estimations of the length of escaped string for
    the worst cases

Fixes: #32
Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>