### PR TITLE
Remove buffer capacity checks

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -13,15 +13,8 @@ var (
 type Formatter interface {
 	// Format appends formatted log data into buf.
 	//
-	// buf will be a zero-length byte slice with a certain capacity to
-	// store formatted log data.  If the capacity of buf is not sufficient,
-	// Format should return (nil, ErrTooLarge).
-	//
 	// Format should return (nil, ErrInvalidKey) if a key in fields is
 	// not valid in the sense of IsValidKey().
-	//
-	// Implementations can assume enough capacity in buf to store
-	// mandatory fields except for msg (and optional fields).
 	Format(buf []byte, l *Logger, t time.Time, severity int,
 		msg string, fields map[string]interface{}) ([]byte, error)
 

--- a/plain.go
+++ b/plain.go
@@ -31,7 +31,6 @@ func (f PlainFormat) Format(buf []byte, l *Logger, t time.Time, severity int,
 	msg string, fields map[string]interface{}) ([]byte, error) {
 	var err error
 
-	// assume enough capacity for mandatory fields (except for msg).
 	buf = t.UTC().AppendFormat(buf, RFC3339Micro)
 	buf = append(buf, ' ')
 	if len(f.Utsname) > 0 {
@@ -63,9 +62,6 @@ func (f PlainFormat) Format(buf []byte, l *Logger, t time.Time, severity int,
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			if cap(buf) < (len(k) + 2) {
-				return nil, ErrTooLarge
-			}
 			buf = append(buf, ' ')
 			buf = append(buf, k...)
 			buf = append(buf, '=')
@@ -80,9 +76,6 @@ func (f PlainFormat) Format(buf []byte, l *Logger, t time.Time, severity int,
 		if _, ok := fields[k]; ok {
 			continue
 		}
-		if cap(buf) < (len(k) + 2) {
-			return nil, ErrTooLarge
-		}
 		buf = append(buf, ' ')
 		buf = append(buf, k...)
 		buf = append(buf, '=')
@@ -92,108 +85,45 @@ func (f PlainFormat) Format(buf []byte, l *Logger, t time.Time, severity int,
 		}
 	}
 
-	if cap(buf) < 1 {
-		return nil, ErrTooLarge
-	}
 	return append(buf, '\n'), nil
 }
 
 func appendPlain(buf []byte, v interface{}) ([]byte, error) {
 	switch t := v.(type) {
 	case nil:
-		if cap(buf) < 4 {
-			return nil, ErrTooLarge
-		}
 		return append(buf, "null"...), nil
 	case bool:
-		if cap(buf) < 5 { // len("false")
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendBool(buf, t), nil
 	case time.Time:
-		// len("2006-01-02T15:04:05.000000Z07:00")
-		if cap(buf) < 32 {
-			return nil, ErrTooLarge
-		}
 		return t.UTC().AppendFormat(buf, RFC3339Micro), nil
 	case int:
-		// len("-9223372036854775807")
-		if cap(buf) < 20 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendInt(buf, int64(t), 10), nil
 	case int8:
-		// len("-128")
-		if cap(buf) < 4 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendInt(buf, int64(t), 10), nil
 	case int16:
-		// len("-32768")
-		if cap(buf) < 6 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendInt(buf, int64(t), 10), nil
 	case int32:
-		// len("-2147483648")
-		if cap(buf) < 11 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendInt(buf, int64(t), 10), nil
 	case int64:
-		// len("-9223372036854775807")
-		if cap(buf) < 20 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendInt(buf, t, 10), nil
 	case uint:
-		// len("18446744073709551615")
-		if cap(buf) < 20 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendUint(buf, uint64(t), 10), nil
 	case uint8:
-		// len("255")
-		if cap(buf) < 3 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendUint(buf, uint64(t), 10), nil
 	case uint16:
-		// len("65535")
-		if cap(buf) < 5 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendUint(buf, uint64(t), 10), nil
 	case uint32:
-		// len("4294967295")
-		if cap(buf) < 10 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendUint(buf, uint64(t), 10), nil
 	case uint64:
-		// len("18446744073709551615")
-		if cap(buf) < 20 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendUint(buf, t, 10), nil
 	case float32:
-		if cap(buf) < 256 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendFloat(buf, float64(t), 'f', -1, 32), nil
 	case float64:
-		if cap(buf) < 256 {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendFloat(buf, t, 'f', -1, 64), nil
 	case string:
 		if !utf8.ValidString(t) {
 			// the next line replaces invalid characters.
 			t = strings.ToValidUTF8(t, string(utf8.RuneError))
-		}
-		// escaped length = 2*len(t) + 2 double quotes
-		if cap(buf) < (len(t)*2 + 2) {
-			return nil, ErrTooLarge
 		}
 		return strconv.AppendQuote(buf, t), nil
 	case encoding.TextMarshaler:
@@ -202,19 +132,12 @@ func appendPlain(buf []byte, v interface{}) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		if cap(buf) < (len(s)*2 + 2) {
-			return nil, ErrTooLarge
-		}
 		return strconv.AppendQuote(buf, string(s)), nil
 	case error:
 		s := t.Error()
 		if !utf8.ValidString(s) {
 			// the next line replaces invalid characters.
 			s = strings.ToValidUTF8(s, string(utf8.RuneError))
-		}
-		// escaped length = 2*len(s) + 2 double quotes
-		if cap(buf) < (len(s)*2 + 2) {
-			return nil, ErrTooLarge
 		}
 		return strconv.AppendQuote(buf, s), nil
 	default:


### PR DESCRIPTION
This PR removes the buffer capacity checks based on the discussion in #32.
I was aware of the remaining capacity check in logger.go but I reverted back the changes because I was unconfident. Maybe we could refactor `logWriter` as `Transformer` to leave the buffer allocation to the standard package, and make `Logger.Writer` returns just `transformer.NewWriter(l.output, &logWriter{})`, but it disallows the concurrent call of `Logger.SetOutput` (not sure how often this method is called like this).